### PR TITLE
[docker][skip ci] removed build files in verilator docker

### DIFF
--- a/Dockerfile-verilator
+++ b/Dockerfile-verilator
@@ -12,7 +12,8 @@ RUN zypper --non-interactive refresh && \
 RUN zypper --non-interactive install \
 		autoconf gcc gcc-c++ flex bison ccache numactl \
 		python3 perl perl-doc gperftools-devel
-RUN git clone https://github.com/verilator/verilator
-RUN cd verilator && git pull && git checkout stable
-RUN cd verilator && autoconf && ./configure && make -j && make install
+RUN git clone https://github.com/verilator/verilator && \
+        cd verilator && git pull && git checkout stable && \
+        autoconf && ./configure && make -j`nproc` && \
+        make install && rm -rf /verilator
 


### PR DESCRIPTION
1. Use `nproc` so that smaller machines (mine included) won't run into out-of-memory issue.
2. Delete verilator build and src files once installation finishes. This reduces the image from 1.5G to 0.9G.